### PR TITLE
4 keine sitzungswochen daten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.0.12-4-keine-sitzungswochen-daten.0](https://github.com/demokratie-live/desktop/compare/v1.0.11...v1.0.12-4-keine-sitzungswochen-daten.0) (2023-12-16)
+
 ### [1.0.11](https://github.com/demokratie-live/desktop/compare/v1.0.10...v1.0.11) (2023-11-01)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "democracy-app.de",
-  "version": "1.0.11",
+  "version": "1.0.12-4-keine-sitzungswochen-daten.0",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -22,7 +22,6 @@ export default function CurrentPage({ conferenceWeek }: Props) {
         listTypes={['CONFERENCEWEEKS_PLANNED']}
         title={`Sitzungswoche - KW ${conferenceWeek.calendarWeek}`}
         description={`Vorgänge, die in der kommenden Sitzungswoche vom ${start} bis ${end} zur Abstimmung stehen`}
-        // description="Vorgänge, die in der kommenden Sitzungswoche zur Abstimmung stehen."
       />
     );
   }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -13,14 +13,24 @@ interface Props {
 }
 
 export default function CurrentPage({ conferenceWeek }: Props) {
-  const start = dayjs(conferenceWeek.start).format('DD.MM.');
-  const end = dayjs(conferenceWeek.end).format('DD.MM.YYYY');
+  if (conferenceWeek) {
+    const start = dayjs(conferenceWeek.start).format('DD.MM.');
+    const end = dayjs(conferenceWeek.end).format('DD.MM.YYYY');
 
+    return (
+      <FilteredPage
+        listTypes={['CONFERENCEWEEKS_PLANNED']}
+        title={`Sitzungswoche - KW ${conferenceWeek.calendarWeek}`}
+        description={`Vorgänge, die in der kommenden Sitzungswoche vom ${start} bis ${end} zur Abstimmung stehen`}
+        // description="Vorgänge, die in der kommenden Sitzungswoche zur Abstimmung stehen."
+      />
+    );
+  }
   return (
     <FilteredPage
       listTypes={['CONFERENCEWEEKS_PLANNED']}
-      title={`Sitzungswoche - KW ${conferenceWeek.calendarWeek}`}
-      description={`Vorgänge, die in der kommenden Sitzungswoche vom ${start} bis ${end} zur Abstimmung stehen`}
+      title={'Sitzungswoche'}
+      description={`Vorgänge, die in der kommenden Sitzungswoche zur Abstimmung stehen`}
       // description="Vorgänge, die in der kommenden Sitzungswoche zur Abstimmung stehen."
     />
   );
@@ -33,9 +43,15 @@ export async function getServerSideProps({ res }: any) {
   );
 
   const client = getClient();
-  const { data } = await client.query({
-    query: GET_CONFERENCE_WEEK,
-  });
+  let data;
+  try {
+    const result = await client.query({
+      query: GET_CONFERENCE_WEEK,
+    });
+    data = result.data;
+  } catch (e) {
+    return { props: {} };
+  }
 
   return {
     props: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1028,7 +1028,12 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001406, caniuse-lite@^1.0.30001538, caniuse-lite@^1.0.30001541:
+caniuse-lite@^1.0.0:
+  version "1.0.30001442"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001442.tgz"
+  integrity sha512-239m03Pqy0hwxYPYR5JwOIxRJfLTWtle9FV8zosfV5pHg+/51uD4nxcUlM8+mWWGfwKtt8lJNHnD3cWw9VZ6ow==
+
+caniuse-lite@^1.0.30001406, caniuse-lite@^1.0.30001538, caniuse-lite@^1.0.30001541:
   version "1.0.30001559"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001559.tgz#95a982440d3d314c471db68d02664fb7536c5a30"
   integrity sha512-cPiMKZgqgkg5LY3/ntGeLFUpi6tzddBNS58A4tnTgQw1zON7u2sZMU7SzOeVH4tj20++9ggL+V6FDOFMTaFFYA==


### PR DESCRIPTION
**Preview:** https://democracy-tailwind-6b4bfnnji-appinteractive.vercel.app/

Ich kann leider nicht ohne weiteres die nächste Sitzungswoche "erraten", da das `currentConferenceWeek` Query null zurückgibt. Ich zeige in diesem PR keine KW an, sondern nur was ich in `procedures` Query bekomme. Ich extrahiere die KW nicht davon, da mir das zu vage ist.